### PR TITLE
Bump AWSAppSync.podspec dependency on AWSCore

### DIFF
--- a/AWSAppSync.podspec
+++ b/AWSAppSync.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.swift_version = '4.2'
 
-  s.dependency 'AWSCore', '~> 2.9.0'
+  s.dependency 'AWSCore', '~> 2.10.0'
   s.dependency 'SQLite.swift', '0.11.6'
 
   # We are pinning to this version as 4.3.1 updates XCode requirements to Xcode


### PR DESCRIPTION
AWSAppSync now depends on AWSCore 2.10.0

A developer would now be able to use the 2.10.0 (latest) versions of SDKs along with AWSAppSync.